### PR TITLE
Fix tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "loxone-mcp-rust"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ futures-util = "0.3"
 
 [package]
 name = "loxone-mcp-rust"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Ralf Anton Beier <ralf_beier@me.com>"]
 license = "MIT OR Apache-2.0"

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
         in
         pkgs.rustPlatform.buildRustPackage {
           pname = "loxone-mcp";
-          version = "0.7.0";
+          version = "0.8.0";
           src = pkgs.lib.cleanSource ./.;
           cargoLock.lockFile = ./Cargo.lock;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,9 +260,47 @@ async fn main() -> Result<()> {
                 use loxone_mcp_rust::config::credentials::LoxoneCredentials;
                 use loxone_mcp_rust::services::SensorTypeRegistry;
 
-                let loxone_url: url::Url = format!("http://{host}").parse().map_err(|e| {
-                    loxone_mcp_rust::LoxoneError::config(format!("Invalid URL: {e}"))
-                })?;
+                // Resolve the Loxone host URL
+                // Supports: plain IPs, explicit URLs, and dns.loxonecloud.com/<ms-id> redirect
+                let loxone_url: url::Url = if host.starts_with("http://") || host.starts_with("https://") {
+                    host.parse().map_err(|e| {
+                        loxone_mcp_rust::LoxoneError::config(format!("Invalid URL: {e}"))
+                    })?
+                } else if host.starts_with("dns.loxonecloud.com") {
+                    // Cloud redirect: dns.loxonecloud.com/<ms-id>
+                    let redirect_url = format!("https://{host}");
+                    info!("🌐 Resolving Loxone cloud redirect: {redirect_url}");
+                    let client = reqwest::Client::builder()
+                        .redirect(reqwest::redirect::Policy::none())
+                        .build()
+                        .map_err(|e| {
+                            loxone_mcp_rust::LoxoneError::config(format!("Failed to create HTTP client: {e}"))
+                        })?;
+                    let resp = client.head(&redirect_url).send().await.map_err(|e| {
+                        loxone_mcp_rust::LoxoneError::connection(format!(
+                            "Failed to reach Loxone cloud redirect: {e}"
+                        ))
+                    })?;
+                    let location = resp.headers().get(reqwest::header::LOCATION)
+                        .and_then(|v| v.to_str().ok())
+                        .ok_or_else(|| {
+                            loxone_mcp_rust::LoxoneError::connection(
+                                "No redirect location from Loxone cloud — Miniserver may be offline".to_string()
+                            )
+                        })?;
+                    info!("✅ Resolved cloud redirect → {location}");
+                    let mut resolved: url::Url = location.parse().map_err(|e| {
+                        loxone_mcp_rust::LoxoneError::config(format!("Invalid redirect URL: {e}"))
+                    })?;
+                    // Strip the path — only keep scheme + host + port as base URL
+                    resolved.set_path("");
+                    resolved
+                } else {
+                    // Local IP or hostname
+                    format!("http://{host}").parse().map_err(|e| {
+                        loxone_mcp_rust::LoxoneError::config(format!("Invalid URL: {e}"))
+                    })?
+                };
 
                 let loxone_cfg = loxone_mcp_rust::config::LoxoneConfig {
                     url: loxone_url,

--- a/src/server/macro_backend.rs
+++ b/src/server/macro_backend.rs
@@ -726,6 +726,7 @@ impl LoxoneMcpServer {
     pub async fn list_devices(
         &self,
         room: Option<String>,
+        _filter: Option<String>,
     ) -> std::result::Result<serde_json::Value, String> {
         self.ensure_connected()?;
 
@@ -771,6 +772,7 @@ impl LoxoneMcpServer {
     pub async fn get_device_info(
         &self,
         device_id: String,
+        _detail: Option<String>,
     ) -> std::result::Result<serde_json::Value, String> {
         self.ensure_connected()?;
 


### PR DESCRIPTION
## Description

This PR fixes MCP schema validation errors caused by two tools (`list_devices` and `get_device_info`) generating invalid `inputSchema.type` values. OpenCode and other MCP clients require **all tool input schemas to have `type: "object"`**, but the macro backend inferred non‑object types from the function signatures.

While addressing this, I also improved [Loxone CloudDNS](https://www.loxone.com/enen/kb/dns-service/) handling and bumped the crate version to `0.8.0` across the project.

The original error:

```json
[
  {
    "code": "invalid_value",
    "values": ["object"],
    "path": ["tools", 7, "inputSchema", "type"],
    "message": "Invalid input: expected \"object\""
  },
  {
    "code": "invalid_value",
    "values": ["object"],
    "path": ["tools", 8, "inputSchema", "type"],
    "message": "Invalid input: expected \"object\""
  }
]
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [x] 🔧 Configuration change
- [ ] 🔒 Security fix

## Related Issue

Fixes https://github.com/avrabe/mcp-loxone/issues/37

## Changes Made

- Bumped crate version from **0.7.0 → 0.8.0** in:
  - `Cargo.toml`
  - `Cargo.lock`
  - `flake.nix`
- Added **CloudDNS redirect resolution**:
  - Supports `dns.loxonecloud.com/<ms-id>`
  - Follows HEAD redirect
  - Normalizes resolved URL
- Fixed MCP schema validation errors by adjusting tool signatures:
  - Added `_filter: Option<String>` to `list_devices`
  - Added `_detail: Option<String>` to `get_device_info`
  - Ensures macro backend generates `inputSchema.type = "object"`
- Improved URL parsing logic:
  - Accepts full URLs
  - Accepts plain IPs
  - Accepts CloudDNS redirect endpoints

## Testing

- [x] Manual testing completed
- [x] Tested with actual Loxone Miniserver
- [x] Verified `tools/list` works in OpenCode
- [x] Verified `tools/call` works for all tools
- [x] Verified no MCP schema validation errors remain
- [ ] Unit tests pass
- [ ] Integration tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have verified no credentials or sensitive data are included
- [x] New and existing functionality works as expected
- [x] MCP clients (OpenCode) successfully load all tools

## Screenshots
<img width="3091" height="1614" alt="image" src="https://github.com/user-attachments/assets/d8d02c08-3670-4f27-87bc-41aa6ae6fea9" />

## Additional Notes

- This PR ensures full MCP compatibility with OpenCode and other strict MCP clients.
- The CloudDNS redirect support significantly improves remote Miniserver usability.
- The schema fix is required for MCP spec compliance and prevents client-side failures.